### PR TITLE
Add GitHub and X links to landing page header

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -573,12 +573,39 @@
       color: #86efac;
       text-decoration: none;
     }
+
+    .top-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 24px;
+    }
+
+    .top-header h1 {
+      margin-bottom: 0;
+    }
+
+    .top-links {
+      display: flex;
+      gap: 16px;
+      padding-top: 8px;
+    }
+
+    .top-links a {
+      font-size: 0.85rem;
+    }
   </style>
 </head>
 
 <body>
   <div class="container">
-    <h1>n.codes</h1>
+    <div class="top-header">
+      <h1>n.codes</h1>
+      <div class="top-links">
+        <a href="https://github.com/yungookim/n.codes" target="_blank">GitHub</a>
+        <a href="https://x.com/dygk_0x1" target="_blank">X</a>
+      </div>
+    </div>
     <p class="tagline">Let users generate their own solution within your app without waiting for your backlog to be
       cleared. It's like having a forward-deployed engineer for every user. Users ask what they need, and they get it
       right there, right now.


### PR DESCRIPTION
## Summary
- Adds GitHub and X social links to the top-right corner of the landing page header
- Links are aligned with the h1 title using flexbox layout
- Uses the same green accent color as footer links for visual consistency

## Test plan
- [ ] Open the landing page and verify links appear in top-right corner
- [ ] Verify links open in new tabs and point to correct URLs
- [ ] Check hover state matches footer link styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)