### PR TITLE
Add demo links to landing page and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Demo
+
+[Try the interactive demo](https://n.codes/demo/) to see the prompt-to-UI experience in action.
+
 ## The Problem
 
 Every SaaS company has the same bottleneck: feature requests. Customers want more all the time. They provide great feedback and ideas, but it's hard to keep up fast enough. Sometimes, they'd ask for something that'd solve their problem, but it's not a priority for the company. This leads to frustration and dissatisfaction.

--- a/public/index.html
+++ b/public/index.html
@@ -602,6 +602,7 @@
     <div class="top-header">
       <h1>n.codes</h1>
       <div class="top-links">
+        <a href="/demo/">Demo</a>
         <a href="https://github.com/yungookim/n.codes" target="_blank">GitHub</a>
         <a href="https://x.com/dygk_0x1" target="_blank">X</a>
       </div>


### PR DESCRIPTION
## Summary
- Add "Demo" link to landing page header navigation (next to GitHub and X)
- Add Demo section at top of README with link to interactive demo

## Test plan
- [ ] Verify Demo link appears in landing page header
- [ ] Verify Demo link in README points to correct URL
- [ ] Click Demo link and confirm it navigates to /demo/

🤖 Generated with [Claude Code](https://claude.ai/code)