### PR TITLE
Add interactive walkthrough to demo page

### DIFF
--- a/public/demo/app.js
+++ b/public/demo/app.js
@@ -324,4 +324,152 @@
     e.stopPropagation();
   });
 
+  // ==================== Walkthrough System ====================
+  const WALKTHROUGH_STORAGE_KEY = 'ncodes-demo-walkthrough-completed';
+
+  // Walkthrough DOM elements
+  const walkthroughOverlay = document.getElementById('walkthrough-overlay');
+  const tooltipWelcome = document.getElementById('tooltip-welcome');
+  const tooltipTrigger = document.getElementById('tooltip-trigger');
+  const tooltipPanel = document.getElementById('tooltip-panel');
+
+  // Walkthrough state
+  let currentStep = 0;
+  let walkthroughActive = false;
+
+  /**
+   * Check if walkthrough has been completed before
+   */
+  function hasCompletedWalkthrough() {
+    try {
+      return localStorage.getItem(WALKTHROUGH_STORAGE_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Mark walkthrough as completed
+   */
+  function markWalkthroughCompleted() {
+    try {
+      localStorage.setItem(WALKTHROUGH_STORAGE_KEY, 'true');
+    } catch {
+      // Ignore storage errors
+    }
+  }
+
+  /**
+   * Start the walkthrough
+   */
+  function startWalkthrough() {
+    walkthroughActive = true;
+    currentStep = 1;
+    walkthroughOverlay.classList.add('active');
+    showStep(1);
+  }
+
+  /**
+   * End the walkthrough
+   */
+  function endWalkthrough() {
+    walkthroughActive = false;
+    currentStep = 0;
+
+    // Hide all tooltips
+    tooltipWelcome.classList.remove('active');
+    tooltipTrigger.classList.remove('active');
+    tooltipPanel.classList.remove('active');
+
+    // Hide overlay
+    walkthroughOverlay.classList.remove('active');
+
+    // Remove highlight from trigger
+    trigger.classList.remove('walkthrough-highlight');
+
+    // Mark as completed
+    markWalkthroughCompleted();
+  }
+
+  /**
+   * Show a specific step
+   */
+  function showStep(step) {
+    currentStep = step;
+
+    // Hide all tooltips first
+    tooltipWelcome.classList.remove('active');
+    tooltipTrigger.classList.remove('active');
+    tooltipPanel.classList.remove('active');
+
+    // Remove highlight
+    trigger.classList.remove('walkthrough-highlight');
+
+    switch (step) {
+      case 1:
+        // Welcome - centered, no highlight
+        tooltipWelcome.classList.add('active');
+        break;
+
+      case 2:
+        // Trigger button - highlight the button
+        tooltipTrigger.classList.add('active');
+        trigger.classList.add('walkthrough-highlight');
+        break;
+
+      case 3:
+        // Panel tooltip - only if panel is open
+        tooltipPanel.classList.add('active');
+        break;
+    }
+  }
+
+  /**
+   * Go to next step
+   */
+  function nextStep() {
+    if (currentStep === 1) {
+      showStep(2);
+    } else if (currentStep === 2) {
+      // Step 2 → open panel and show step 3
+      openPanel();
+      // Small delay to let panel animate open
+      setTimeout(() => showStep(3), 300);
+    } else if (currentStep === 3) {
+      endWalkthrough();
+    }
+  }
+
+  /**
+   * Go to previous step
+   */
+  function prevStep() {
+    if (currentStep === 2) {
+      showStep(1);
+    } else if (currentStep === 3) {
+      closePanel();
+      showStep(2);
+    }
+  }
+
+  // Make walkthrough functions globally accessible (for onclick handlers)
+  window.startWalkthrough = startWalkthrough;
+  window.endWalkthrough = endWalkthrough;
+  window.nextStep = nextStep;
+  window.prevStep = prevStep;
+
+  // Handle trigger click during walkthrough step 2
+  const originalTriggerClick = trigger.onclick;
+  trigger.addEventListener('click', () => {
+    if (walkthroughActive && currentStep === 2) {
+      // Panel will open via existing handler, then show step 3
+      setTimeout(() => showStep(3), 300);
+    }
+  });
+
+  // Auto-start walkthrough on first visit (after small delay for page to settle)
+  if (!hasCompletedWalkthrough()) {
+    setTimeout(startWalkthrough, 500);
+  }
+
 })();

--- a/public/demo/index.html
+++ b/public/demo/index.html
@@ -126,9 +126,9 @@
 
   <!-- n.codes Floating Trigger Button -->
   <button id="ncodes-trigger" class="ncodes-trigger" title="Open n.codes">
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-      <path d="M12 3L14.5 8.5L20 9.27L16 13.14L16.9 19L12 16.27L7.1 19L8 13.14L4 9.27L9.5 8.5L12 3Z" fill="currentColor"
-        stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" />
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+      <path d="M7 4h-3v16h3" stroke-linecap="round" stroke-linejoin="round"></path>
+      <path d="M17 4h3v16h-3" stroke-linecap="round" stroke-linejoin="round"></path>
     </svg>
     <span>Build with AI</span>
   </button>
@@ -538,6 +538,56 @@
       </div>
     </div>
   </template>
+
+  <!-- Walkthrough Overlay -->
+  <div id="walkthrough-overlay" class="walkthrough-overlay">
+    <div class="walkthrough-backdrop"></div>
+  </div>
+
+  <!-- Walkthrough Tooltips -->
+  <div id="tooltip-welcome" class="walkthrough-tooltip" data-step="1">
+    <div class="tooltip-content">
+      <div class="tooltip-icon">&#10024;</div>
+      <h3>Welcome to n.codes</h3>
+      <p>This demo shows how users can build custom features with just a prompt. Let's walk through it!</p>
+    </div>
+    <div class="tooltip-footer">
+      <span class="tooltip-step">1 of 3</span>
+      <div class="tooltip-actions">
+        <button class="tooltip-btn skip" onclick="endWalkthrough()">Skip</button>
+        <button class="tooltip-btn primary" onclick="nextStep()">Get Started</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="tooltip-trigger" class="walkthrough-tooltip" data-step="2">
+    <div class="tooltip-arrow"></div>
+    <div class="tooltip-content">
+      <h3>Click "Build with AI"</h3>
+      <p>This button opens the AI builder. Users can describe what they need in plain English.</p>
+    </div>
+    <div class="tooltip-footer">
+      <span class="tooltip-step">2 of 3</span>
+      <div class="tooltip-actions">
+        <button class="tooltip-btn skip" onclick="endWalkthrough()">Skip</button>
+        <button class="tooltip-btn secondary" onclick="prevStep()">Back</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="tooltip-panel" class="walkthrough-tooltip" data-step="3">
+    <div class="tooltip-arrow"></div>
+    <div class="tooltip-content">
+      <h3>Describe or select an example</h3>
+      <p>Type what you need, or click one of the examples below to see the AI generate a working UI instantly.</p>
+    </div>
+    <div class="tooltip-footer">
+      <span class="tooltip-step">3 of 3</span>
+      <div class="tooltip-actions">
+        <button class="tooltip-btn primary" onclick="endWalkthrough()">Got it!</button>
+      </div>
+    </div>
+  </div>
 
   <script src="app.js"></script>
 </body>

--- a/public/demo/styles.css
+++ b/public/demo/styles.css
@@ -255,6 +255,22 @@ body {
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
   transition: all 0.2s ease;
   z-index: 1000;
+  animation: breathe 3s infinite ease-in-out;
+}
+
+@keyframes breathe {
+  0% {
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    border-color: var(--border-color);
+  }
+  50% {
+    box-shadow: 0 0 25px var(--accent-dim), 0 0 10px var(--accent-dim);
+    border-color: var(--accent);
+  }
+  100% {
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    border-color: var(--border-color);
+  }
 }
 
 .ncodes-trigger svg {
@@ -1020,5 +1036,238 @@ body {
 
   .stats-grid {
     grid-template-columns: 1fr;
+  }
+}
+
+/* ==================== Walkthrough Overlay ==================== */
+.walkthrough-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.walkthrough-overlay.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.walkthrough-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+}
+
+/* Spotlight effect for highlighted elements */
+.walkthrough-spotlight {
+  position: relative;
+  z-index: 2001;
+  box-shadow: 0 0 0 4px var(--accent), 0 0 0 9999px rgba(0, 0, 0, 0.75);
+  border-radius: inherit;
+}
+
+/* ==================== Walkthrough Tooltips ==================== */
+.walkthrough-tooltip {
+  position: fixed;
+  z-index: 2002;
+  width: 340px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(10px);
+  transition: all 0.3s ease;
+}
+
+.walkthrough-tooltip.active {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+/* Welcome tooltip - centered */
+.walkthrough-tooltip[data-step="1"] {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.walkthrough-tooltip[data-step="1"].active {
+  transform: translate(-50%, -50%);
+}
+
+/* Trigger tooltip - above the button */
+.walkthrough-tooltip[data-step="2"] {
+  bottom: 70px;
+  left: 50%;
+  transform: translateX(-50%) translateY(10px);
+}
+
+.walkthrough-tooltip[data-step="2"].active {
+  transform: translateX(-50%) translateY(0);
+}
+
+/* Panel tooltip - to the side of panel */
+.walkthrough-tooltip[data-step="3"] {
+  bottom: 120px;
+  left: calc(50% + 220px);
+  transform: translateY(10px);
+}
+
+.walkthrough-tooltip[data-step="3"].active {
+  transform: translateY(0);
+}
+
+/* Tooltip arrow */
+.tooltip-arrow {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-top: none;
+  border-left: none;
+  transform: rotate(45deg);
+}
+
+.walkthrough-tooltip[data-step="2"] .tooltip-arrow {
+  bottom: -7px;
+  left: 50%;
+  margin-left: -6px;
+}
+
+.walkthrough-tooltip[data-step="3"] .tooltip-arrow {
+  left: -7px;
+  top: 50%;
+  margin-top: -6px;
+  transform: rotate(135deg);
+}
+
+/* Tooltip content */
+.tooltip-content {
+  padding: 24px;
+}
+
+.tooltip-icon {
+  font-size: 32px;
+  margin-bottom: 12px;
+}
+
+.tooltip-content h3 {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-main);
+  margin-bottom: 8px;
+}
+
+.tooltip-content p {
+  font-size: 14px;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+/* Tooltip footer */
+.tooltip-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  border-top: 1px solid var(--border-color);
+  background: var(--bg-body);
+  border-radius: 0 0 16px 16px;
+}
+
+.tooltip-step {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.tooltip-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.tooltip-btn {
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  transition: all 0.15s ease;
+}
+
+.tooltip-btn.skip {
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.tooltip-btn.skip:hover {
+  color: var(--text-main);
+}
+
+.tooltip-btn.secondary {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+}
+
+.tooltip-btn.secondary:hover {
+  color: var(--text-main);
+  background: var(--bg-panel);
+}
+
+.tooltip-btn.primary {
+  background: var(--accent);
+  color: #000;
+}
+
+.tooltip-btn.primary:hover {
+  background: var(--accent-hover);
+}
+
+/* Pulsing highlight for trigger button during walkthrough */
+.ncodes-trigger.walkthrough-highlight {
+  animation: pulse-highlight 1.5s infinite ease-in-out;
+  z-index: 2001;
+}
+
+@keyframes pulse-highlight {
+  0% {
+    box-shadow: 0 0 0 0 var(--accent), 0 0 0 0 rgba(74, 222, 128, 0.4);
+  }
+  50% {
+    box-shadow: 0 0 0 4px var(--accent), 0 0 0 12px rgba(74, 222, 128, 0.2);
+  }
+  100% {
+    box-shadow: 0 0 0 0 var(--accent), 0 0 0 0 rgba(74, 222, 128, 0.4);
+  }
+}
+
+/* Responsive walkthrough */
+@media (max-width: 768px) {
+  .walkthrough-tooltip {
+    width: calc(100% - 32px);
+    left: 16px !important;
+    right: 16px !important;
+  }
+
+  .walkthrough-tooltip[data-step="3"] {
+    left: 16px;
+    bottom: auto;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .walkthrough-tooltip[data-step="3"].active {
+    transform: translateY(-50%);
+  }
+
+  .walkthrough-tooltip[data-step="3"] .tooltip-arrow {
+    display: none;
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -594,6 +594,39 @@
     .top-links a {
       font-size: 0.85rem;
     }
+
+    .demo-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 24px;
+      background: var(--accent);
+      color: #000;
+      font-weight: 600;
+      font-size: 1rem;
+      border-radius: 10px;
+      transition: all 0.2s ease;
+      margin-bottom: 32px;
+    }
+
+    .demo-cta:hover {
+      background: #86efac;
+      color: #000;
+      transform: translateY(-2px);
+      box-shadow: 0 8px 20px rgba(74, 222, 128, 0.3);
+    }
+
+    .demo-cta-icon {
+      font-size: 1.1rem;
+    }
+
+    .demo-cta-arrow {
+      transition: transform 0.2s ease;
+    }
+
+    .demo-cta:hover .demo-cta-arrow {
+      transform: translateX(4px);
+    }
   </style>
 </head>
 
@@ -607,9 +640,15 @@
         <a href="https://x.com/dygk_0x1" target="_blank">X</a>
       </div>
     </div>
-    <p class="tagline">Let users generate their own solution within your app without waiting for your backlog to be
-      cleared. It's like having a forward-deployed engineer for every user. Users ask what they need, and they get it
-      right there, right now.
+    <p class="tagline">Let users generate their own solutions within your app without waiting for your backlog to clear.
+      It's like having a forward-deployed engineer for every user. Users ask for what they need, agents build it
+      instantly.</p>
+
+    <a href="/demo/" class="demo-cta">
+      <span class="demo-cta-icon">&#10024;</span>
+      Try the interactive demo
+      <span class="demo-cta-arrow">&rarr;</span>
+    </a>
 
     <h2>The Problem</h2>
 


### PR DESCRIPTION
## Summary
- Add 3-step interactive walkthrough for first-time demo visitors
- Welcome tooltip introduces the concept, then highlights "Build with AI" button with pulsing animation
- Final step explains the prompt panel after it opens
- Uses localStorage to show walkthrough only once per visitor
- Add prominent demo CTA button to landing page hero section

## Test plan
- [ ] Visit demo page for first time - walkthrough should appear
- [ ] Click through all 3 steps to completion
- [ ] Refresh page - walkthrough should NOT appear again
- [ ] Clear localStorage and refresh - walkthrough should appear again
- [ ] Test Skip button at each step
- [ ] Test Back button on steps 2 and 3
- [ ] Verify responsive layout on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)