### PR TITLE
Finalize capability map v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,40 @@ The LLM doesn't write arbitrary code.
 - Store local API keys in `.env.local` (not `.env`) so they stay out of version control.
 - Capability map generation is LLM-based and requires a configured provider/model plus a valid API key.
 
+### Capability map example
+When you add or change a route, `n.codes sync` turns it into structured capabilities.
+
+Input route:
+```ts
+// pages/api/bookings/[id].ts
+export async function GET(req) {
+  // fetch booking by id
+}
+```
+
+Output capability map snippet:
+```yaml
+queries:
+  getBooking:
+    endpoint:
+      method: "GET"
+      path: "/api/bookings/:id"
+    description: "Retrieves a booking by ID with its related details."
+    entities:
+      - "Booking"
+    analysisSource: "llm"
+
+entities:
+  Booking:
+    fields:
+      - id
+      - status
+    sources:
+      - "prisma"
+    referencedBy:
+      - getBooking
+```
+
 1. It reads through your frontend components to understand the capabilities of your app and styles. It then uses that knowledge to build the UI that the user asks for. It keeps a consistent style.
 
 2. It reads through your backend APIs, docs, and schemas to create a *"capability map"* of your app. This includes entities, actions, queries, and constraints.

--- a/cli/lib/args.js
+++ b/cli/lib/args.js
@@ -1,4 +1,4 @@
-const COMMANDS = new Set(['init', 'dev', 'sync', 'validate']);
+const COMMANDS = new Set(['init', 'dev', 'sync', 'validate', 'reset']);
 
 function normalizeCommand(value) {
   if (!value) return null;
@@ -15,6 +15,8 @@ function parseArgs(argv) {
     dryRun: false,
     force: false,
     configPath: null,
+    sample: null,
+    all: false,
   };
   const positionals = [];
   const unknown = [];
@@ -35,6 +37,25 @@ function parseArgs(argv) {
     }
     if (arg === '--force' || arg === '-f') {
       flags.force = true;
+      continue;
+    }
+    if (arg === '--sample' || arg === '-s') {
+      const next = argv[i + 1];
+      if (!next || next.startsWith('-')) {
+        unknown.push(arg);
+      } else {
+        const parsed = Number.parseInt(next, 10);
+        if (Number.isNaN(parsed) || parsed <= 0) {
+          unknown.push(arg);
+        } else {
+          flags.sample = parsed;
+          i += 1;
+        }
+      }
+      continue;
+    }
+    if (arg === '--all' || arg === '-a') {
+      flags.all = true;
       continue;
     }
     if (arg === '--config') {

--- a/cli/lib/capability-map.js
+++ b/cli/lib/capability-map.js
@@ -666,8 +666,9 @@ const ACTION_VERBS = new Set([
   'verify',
 ]);
 
-function inferCapabilitiesFromFiles(fileIndex, { readFile } = {}) {
+function inferCapabilityMapAndRoutes(fileIndex, { readFile } = {}) {
   const map = defaultCapabilityMap();
+  const routes = [];
   const filePaths = Object.keys(fileIndex);
   map.meta.filesAnalyzed = filePaths.length;
   const usedActionNames = new Set();
@@ -691,6 +692,12 @@ function inferCapabilitiesFromFiles(fileIndex, { readFile } = {}) {
             endpoint: { method: entry.method, path: entry.path },
             description: buildQueryDescription({ path: entry.path }),
           };
+          routes.push({
+            name: queryName,
+            method: entry.method,
+            path: entry.path,
+            file: normalized,
+          });
           return;
         }
         const actionName = ensureUniqueName(entry.name || name, usedActionNames);
@@ -698,12 +705,22 @@ function inferCapabilitiesFromFiles(fileIndex, { readFile } = {}) {
           endpoint: { method: entry.method, path: entry.path },
           description: buildActionDescription({ method: entry.method, path: entry.path }),
         };
+        routes.push({
+          name: actionName,
+          method: entry.method,
+          path: entry.path,
+          file: normalized,
+        });
       });
       return;
     }
   });
 
-  return map;
+  return { map, routes };
+}
+
+function inferCapabilitiesFromFiles(fileIndex, { readFile } = {}) {
+  return inferCapabilityMapAndRoutes(fileIndex, { readFile }).map;
 }
 
 function applyChangedFiles(map, changedFiles) {
@@ -732,6 +749,7 @@ module.exports = {
   summarizeCapabilityMap,
   validateCapabilityMap,
   toCapabilityName,
+  inferCapabilityMapAndRoutes,
   inferCapabilitiesFromFiles,
   applyChangedFiles,
   enrichCapabilityWithAnalysis,

--- a/cli/lib/config.js
+++ b/cli/lib/config.js
@@ -4,6 +4,7 @@ function defaultConfig() {
     model: 'default',
     projectName: null,
     capabilityMapPath: 'n.codes.capabilities.yaml',
+    allowHeuristicFallback: false,
   };
 }
 

--- a/cli/lib/dev.js
+++ b/cli/lib/dev.js
@@ -1,19 +1,20 @@
 const { loadConfig } = require('./config');
 const { collectFiles, buildFileIndex, diffFileIndex, selectChangedFiles } = require('./introspect');
-const { inferCapabilitiesFromFiles, applyChangedFiles, summarizeCapabilityMap, enrichCapabilityWithAnalysis } = require('./capability-map');
-const { loadCache, saveCache, hashContent, getAnalysisCache, setAnalysisCache } = require('./cache');
+const { inferCapabilityMapAndRoutes, applyChangedFiles, summarizeCapabilityMap, enrichCapabilityWithAnalysis } = require('./capability-map');
+const { loadCache, saveCache } = require('./cache');
+const { mergeEntities } = require('./analyzer');
 const { resolveCapabilityMapPath, writeCapabilityMap, analyzeRoutesWithLLM } = require('./sync');
 
 function buildIncrementalMap({ fileIndex, changedFiles, config, readFile }) {
-  const base = inferCapabilitiesFromFiles(fileIndex, { readFile });
-  const updated = applyChangedFiles(base, changedFiles);
+  const { map, routes } = inferCapabilityMapAndRoutes(fileIndex, { readFile });
+  const updated = applyChangedFiles(map, changedFiles);
   if (config.projectName) {
     updated.projectName = config.projectName;
   }
-  return updated;
+  return { map: updated, routes };
 }
 
-function runDev({ cwd, fs, path, io, configPath, extensions, excludeDirs }) {
+async function runDev({ cwd, fs, path, io, configPath, extensions, excludeDirs, force = false }) {
   const { config } = loadConfig({ cwd, fs, path, configPath });
   const files = collectFiles({ cwd, fs, path, extensions, excludeDirs });
   const index = buildFileIndex(files, { cwd, fs, path });
@@ -22,21 +23,69 @@ function runDev({ cwd, fs, path, io, configPath, extensions, excludeDirs }) {
   const diff = diffFileIndex(previousIndex, index);
   const changedFiles = selectChangedFiles(diff);
 
-  const map = buildIncrementalMap({
+  const { map, routes } = buildIncrementalMap({
     fileIndex: index,
     changedFiles,
     config,
     readFile: (filePath) => fs.readFileSync(path.join(cwd, filePath), 'utf8'),
   });
+  const activeCache = cache || {};
+  let analysisResults = [];
+
+  if (routes.length > 0) {
+    analysisResults = await analyzeRoutesWithLLM({
+      routes,
+      cwd,
+      fs,
+      path,
+      config,
+      io,
+      cache: activeCache,
+      force
+    });
+    const entities = mergeEntities(analysisResults);
+    map.entities = entities;
+    activeCache.entities = entities;
+
+    analysisResults.forEach((result) => {
+      if (map.actions[result.capabilityName]) {
+        map.actions[result.capabilityName] = enrichCapabilityWithAnalysis(
+          map.actions[result.capabilityName],
+          result
+        );
+        return;
+      }
+      if (map.queries[result.capabilityName]) {
+        map.queries[result.capabilityName] = enrichCapabilityWithAnalysis(
+          map.queries[result.capabilityName],
+          result
+        );
+      }
+    });
+  }
+
   const mapPath = resolveCapabilityMapPath({ cwd, path, config });
 
   writeCapabilityMap({ fs, mapPath, map });
-  saveCache({ cwd, fs, path, cache: { fileIndex: index } });
+  activeCache.fileIndex = index;
+  saveCache({ cwd, fs, path, cache: activeCache });
 
   const summary = summarizeCapabilityMap(map);
   io.log(`Incremental capability map updated at ${mapPath}`);
   io.log(`Changed files: ${changedFiles.length}`);
   io.log(`Entities: ${summary.entities}, Actions: ${summary.actions}, Queries: ${summary.queries}, Components: ${summary.components}`);
+
+  if (analysisResults.length > 0) {
+    const llmCount = analysisResults.filter((result) => result.analysisSource === 'llm').length;
+    const heuristicCount = analysisResults.length - llmCount;
+    io.log(`${analysisResults.length} routes analyzed (${llmCount} LLM, ${heuristicCount} heuristic fallback)`);
+    if (heuristicCount > 0) {
+      const failed = analysisResults.filter((result) => result.analysisSource === 'heuristic');
+      const sample = failed.slice(0, 5).map((result) => result.capabilityName).join(', ');
+      io.log(`Heuristic fallback: ${sample}${failed.length > 5 ? ', ...' : ''}`);
+      io.log('Use --force to retry failed routes.');
+    }
+  }
 
   return { mapPath, changedFiles, summary };
 }

--- a/cli/lib/fs-utils.js
+++ b/cli/lib/fs-utils.js
@@ -4,6 +4,9 @@ function createDryRunFs(fs, io) {
     writeFileSync(targetPath) {
       io.log(`[dry-run] write ${targetPath}`);
     },
+    unlinkSync(targetPath) {
+      io.log(`[dry-run] delete ${targetPath}`);
+    },
   };
 }
 

--- a/cli/lib/reset.js
+++ b/cli/lib/reset.js
@@ -1,0 +1,64 @@
+const { resolveConfigPath, loadConfig } = require('./config');
+const { resolveCapabilityMapPath } = require('./sync');
+const { resolveCachePath } = require('./cache');
+
+function safeUnlink(fs, targetPath, io, label) {
+  if (!fs.existsSync(targetPath)) {
+    io.log(`No ${label} found at ${targetPath}`);
+    return false;
+  }
+  fs.unlinkSync(targetPath);
+  io.log(`Deleted ${label}: ${targetPath}`);
+  return true;
+}
+
+function matchesNcodesFile(name) {
+  if (!name) return false;
+  if (name.startsWith('.env')) return false;
+  return name.startsWith('n.codes.') || name.startsWith('.n.codes.');
+}
+
+function removeAllNcodesFiles({ cwd, fs, path, io }) {
+  const entries = fs.readdirSync(cwd, { withFileTypes: true });
+  let removed = 0;
+  entries.forEach((entry) => {
+    if (!entry.isFile() && !entry.isSymbolicLink()) return;
+    if (!matchesNcodesFile(entry.name)) return;
+    const targetPath = path.join(cwd, entry.name);
+    safeUnlink(fs, targetPath, io, 'file');
+    removed += 1;
+  });
+  if (removed === 0) {
+    io.log('No additional n.codes files found in current directory.');
+  }
+  return removed;
+}
+
+function runReset({ cwd, fs, path, io, configPath, all = false }) {
+  const { config } = loadConfig({ cwd, fs, path, configPath });
+  const resolvedConfigPath = resolveConfigPath({ cwd, path, configPath });
+  const mapPath = resolveCapabilityMapPath({ cwd, path, config });
+  const cachePath = resolveCachePath({ cwd, path });
+
+  const deleted = {
+    config: safeUnlink(fs, resolvedConfigPath, io, 'config'),
+    map: safeUnlink(fs, mapPath, io, 'capability map'),
+    cache: safeUnlink(fs, cachePath, io, 'cache'),
+  };
+
+  if (all) {
+    const defaultMapPath = resolveCapabilityMapPath({
+      cwd,
+      path,
+      config: { capabilityMapPath: 'n.codes.capabilities.yaml' }
+    });
+    if (defaultMapPath !== mapPath) {
+      deleted.defaultMap = safeUnlink(fs, defaultMapPath, io, 'capability map');
+    }
+    deleted.additional = removeAllNcodesFiles({ cwd, fs, path, io });
+  }
+
+  return deleted;
+}
+
+module.exports = { runReset };

--- a/cli/lib/sync.js
+++ b/cli/lib/sync.js
@@ -2,6 +2,7 @@ const { loadConfig } = require('./config');
 const { collectFiles, buildFileIndex } = require('./introspect');
 const {
   inferCapabilitiesFromFiles,
+  inferCapabilityMapAndRoutes,
   renderCapabilityMapYaml,
   summarizeCapabilityMap,
   enrichCapabilityWithAnalysis,
@@ -29,6 +30,34 @@ function buildCapabilityMap({ fileIndex, config, readFile }) {
   return base;
 }
 
+function buildRouteContextHash(routeContext) {
+  if (!routeContext.imports || routeContext.imports.length === 0) {
+    return hashContent(routeContext.routeContent || '');
+  }
+  const parts = [routeContext.routeContent || ''];
+  for (const imp of routeContext.imports) {
+    parts.push(`\n/* ${imp.path} */\n${imp.content || ''}`);
+  }
+  if (routeContext.typeImports && routeContext.typeImports.length) {
+    parts.push(`\n/* types */\n${routeContext.typeImports.join(',')}`);
+  }
+  return hashContent(parts.join('\n'));
+}
+
+function sortRoutesForSampling(routes) {
+  return routes.slice().sort((a, b) => {
+    if (a.file !== b.file) return a.file.localeCompare(b.file);
+    if (a.method !== b.method) return a.method.localeCompare(b.method);
+    if (a.path !== b.path) return a.path.localeCompare(b.path);
+    return a.name.localeCompare(b.name);
+  });
+}
+
+function sampleRoutes(routes, sample) {
+  if (!sample || sample <= 0 || sample >= routes.length) return routes;
+  return sortRoutesForSampling(routes).slice(0, sample);
+}
+
 async function analyzeRoutesWithLLM({
   routes,
   cwd,
@@ -41,7 +70,12 @@ async function analyzeRoutesWithLLM({
   force = false
 }) {
   const semaphore = createSemaphore(concurrency);
-  const results = [];
+  const total = routes.length;
+  let completed = 0;
+
+  if (io && typeof io.log === 'function' && total > 0) {
+    io.log(`Analyzing routes... [0/${total}]`);
+  }
 
   const tasks = routes.map(async (route) => {
     await semaphore.acquire();
@@ -61,8 +95,15 @@ async function analyzeRoutesWithLLM({
         };
       }
 
-      const routeContent = fs.readFileSync(routeFullPath, 'utf8');
-      const contentHash = hashContent(routeContent);
+      // Build route context with imports
+      const routeContext = buildRouteContext({
+        cwd,
+        routeFile: route.file,
+        fs,
+        path
+      });
+
+      const contentHash = buildRouteContextHash(routeContext);
 
       // Check cache unless force flag is set
       if (!force) {
@@ -80,25 +121,23 @@ async function analyzeRoutesWithLLM({
         }
       }
 
-      // Build route context with imports
-      const routeContext = buildRouteContext({
-        cwd,
-        routeFile: route.file,
-        fs,
-        path
-      });
-
       // Generate heuristic description as fallback
       const heuristicDescription = `Handles ${route.method} requests to ${route.path}. Processes the request and returns a response.`;
 
       // Call LLM for analysis
-      const llmResult = await analyzeWithLLM({
-        routeContext,
-        method: route.method,
-        path: route.path,
-        config,
-        heuristicDescription
-      });
+      let llmResult;
+      try {
+        llmResult = await analyzeWithLLM({
+          routeContext,
+          method: route.method,
+          path: route.path,
+          config,
+          heuristicDescription
+        });
+      } catch (error) {
+        const message = `LLM analysis failed for ${route.file} (${route.method} ${route.path}): ${error.message}`;
+        throw new Error(message);
+      }
 
       const analysisResult = buildRouteAnalysisResult({
         routeFile: route.file,
@@ -118,6 +157,10 @@ async function analyzeRoutesWithLLM({
       return analysisResult;
     } finally {
       semaphore.release();
+      completed += 1;
+      if (io && typeof io.log === 'function' && total > 0) {
+        io.log(`Analyzing routes... [${completed}/${total}]`);
+      }
     }
   });
 
@@ -125,23 +168,79 @@ async function analyzeRoutesWithLLM({
   return taskResults;
 }
 
-function runSync({ cwd, fs, path, io, configPath, extensions, excludeDirs, force = false }) {
+async function runSync({ cwd, fs, path, io, configPath, extensions, excludeDirs, force = false, sample = null }) {
   const { config } = loadConfig({ cwd, fs, path, configPath });
   const files = collectFiles({ cwd, fs, path, extensions, excludeDirs });
   const index = buildFileIndex(files, { cwd, fs, path });
-  const map = buildCapabilityMap({
-    fileIndex: index,
-    config,
+  const { map, routes } = inferCapabilityMapAndRoutes(index, {
     readFile: (filePath) => fs.readFileSync(path.join(cwd, filePath), 'utf8'),
   });
+  if (config.projectName) {
+    map.projectName = config.projectName;
+  }
+
+  const { cache } = loadCache({ cwd, fs, path });
+  const activeCache = cache || {};
+  let analysisResults = [];
+
+  if (routes.length > 0) {
+    const sampledRoutes = sampleRoutes(routes, sample);
+    if (sampledRoutes.length !== routes.length) {
+      io.log(`Sampling ${sampledRoutes.length} of ${routes.length} routes for LLM analysis.`);
+    }
+    analysisResults = await analyzeRoutesWithLLM({
+      routes: sampledRoutes,
+      cwd,
+      fs,
+      path,
+      config,
+      io,
+      cache: activeCache,
+      force
+    });
+    const entities = mergeEntities(analysisResults);
+    map.entities = entities;
+    activeCache.entities = entities;
+
+    analysisResults.forEach((result) => {
+      if (map.actions[result.capabilityName]) {
+        map.actions[result.capabilityName] = enrichCapabilityWithAnalysis(
+          map.actions[result.capabilityName],
+          result
+        );
+        return;
+      }
+      if (map.queries[result.capabilityName]) {
+        map.queries[result.capabilityName] = enrichCapabilityWithAnalysis(
+          map.queries[result.capabilityName],
+          result
+        );
+      }
+    });
+  }
+
+  activeCache.fileIndex = index;
+  saveCache({ cwd, fs, path, cache: activeCache });
+
   const mapPath = resolveCapabilityMapPath({ cwd, path, config });
 
   writeCapabilityMap({ fs, mapPath, map });
-  saveCache({ cwd, fs, path, cache: { fileIndex: index } });
 
   const summary = summarizeCapabilityMap(map);
   io.log(`Capability map written to ${mapPath}`);
   io.log(`Entities: ${summary.entities}, Actions: ${summary.actions}, Queries: ${summary.queries}, Components: ${summary.components}`);
+
+  if (analysisResults.length > 0) {
+    const llmCount = analysisResults.filter((result) => result.analysisSource === 'llm').length;
+    const heuristicCount = analysisResults.length - llmCount;
+    io.log(`${analysisResults.length} routes analyzed (${llmCount} LLM, ${heuristicCount} heuristic fallback)`);
+    if (heuristicCount > 0) {
+      const failed = analysisResults.filter((result) => result.analysisSource === 'heuristic');
+      const sample = failed.slice(0, 5).map((result) => result.capabilityName).join(', ');
+      io.log(`Heuristic fallback: ${sample}${failed.length > 5 ? ', ...' : ''}`);
+      io.log('Use --force to retry failed routes.');
+    }
+  }
 
   return { mapPath, summary };
 }
@@ -150,6 +249,7 @@ module.exports = {
   resolveCapabilityMapPath,
   writeCapabilityMap,
   buildCapabilityMap,
+  buildRouteContextHash,
   runSync,
   analyzeRoutesWithLLM,
 };

--- a/cli/lib/usage.js
+++ b/cli/lib/usage.js
@@ -14,6 +14,9 @@ function formatUsage() {
     'Options:',
     '  --config <path>   Path to n.codes.config.json',
     '  --dry-run         Skip writing files',
+    '  -f, --force       Re-analyze routes, ignoring cache',
+    '  -s, --sample <n>  Analyze only N routes with LLM (sync only)',
+    '  -a, --all         Delete all n.codes files in the current directory (reset only)',
     '  -h, --help        Show help',
     '  -v, --version     Show version',
   ].join('\n');

--- a/cli/tests/args.test.js
+++ b/cli/tests/args.test.js
@@ -50,3 +50,15 @@ test('parseArgs recognizes -f shorthand for force', () => {
   assert.equal(result.command, 'sync');
   assert.equal(result.flags.force, true);
 });
+
+test('parseArgs parses sample size', () => {
+  const result = parseArgs(['sync', '--sample', '5']);
+  assert.equal(result.command, 'sync');
+  assert.equal(result.flags.sample, 5);
+});
+
+test('parseArgs recognizes --all flag', () => {
+  const result = parseArgs(['reset', '--all']);
+  assert.equal(result.command, 'reset');
+  assert.equal(result.flags.all, true);
+});

--- a/cli/tests/bin.test.js
+++ b/cli/tests/bin.test.js
@@ -16,7 +16,7 @@ test('dispatchCommand returns error for unknown command', async () => {
 
 test('dispatchCommand runs init', async () => {
   const cwd = createTempDir();
-  const io = createMemoryIO({ responses: ['openai', 'gpt-4o', 'Demo', 'test-key'] });
+  const io = createMemoryIO({ responses: ['openai', 'gpt-4o', 'n', 'Demo', 'test-key'] });
   const code = await dispatchCommand('init', { cwd, fs, path, io, configPath: null });
   assert.equal(code, 0);
   assert.ok(fs.existsSync(path.join(cwd, 'n.codes.config.json')));
@@ -25,7 +25,7 @@ test('dispatchCommand runs init', async () => {
 test('dispatchCommand runs dev', async () => {
   const cwd = createTempDir();
   writeFile(cwd, 'src/components/Card.tsx', 'export const Card = () => null;');
-  const io = createMemoryIO({ responses: ['openai', 'gpt-4o', 'Demo', 'test-key'] });
+  const io = createMemoryIO({ responses: ['openai', 'gpt-4o', 'n', 'Demo', 'test-key'] });
   const code = await dispatchCommand('dev', { cwd, fs, path, io, configPath: null });
   assert.equal(code, 0);
 });
@@ -35,7 +35,7 @@ test('dispatchCommand runs validate', async () => {
   const mapPath = path.join(cwd, 'n.codes.capabilities.yaml');
   const map = defaultCapabilityMap({ generatedAt: '2026-01-01T00:00:00Z' });
   fs.writeFileSync(mapPath, renderCapabilityMapYaml(map), 'utf8');
-  const io = createMemoryIO({ responses: ['openai', 'gpt-4o', 'Demo', 'test-key'] });
+  const io = createMemoryIO({ responses: ['openai', 'gpt-4o', 'n', 'Demo', 'test-key'] });
   const code = await dispatchCommand('validate', { cwd, fs, path, io, configPath: null });
   assert.equal(code, 0);
 });
@@ -46,9 +46,23 @@ test('dispatchCommand returns error when validate fails', async () => {
   const map = defaultCapabilityMap({ generatedAt: null });
   delete map.version;
   fs.writeFileSync(mapPath, renderCapabilityMapYaml(map), 'utf8');
-  const io = createMemoryIO({ responses: ['openai', 'gpt-4o', 'Demo', 'test-key'] });
+  const io = createMemoryIO({ responses: ['openai', 'gpt-4o', 'n', 'Demo', 'test-key'] });
   const code = await dispatchCommand('validate', { cwd, fs, path, io, configPath: null });
   assert.equal(code, 1);
+});
+
+test('dispatchCommand runs reset', async () => {
+  const cwd = createTempDir();
+  const configPath = path.join(cwd, 'n.codes.config.json');
+  fs.writeFileSync(configPath, JSON.stringify({ capabilityMapPath: 'n.codes.capabilities.yaml' }), 'utf8');
+  fs.writeFileSync(path.join(cwd, 'n.codes.capabilities.yaml'), 'version: 1', 'utf8');
+  fs.writeFileSync(path.join(cwd, '.n.codes.cache.json'), '{}', 'utf8');
+  const io = createMemoryIO();
+  const code = await dispatchCommand('reset', { cwd, fs, path, io, configPath: null });
+  assert.equal(code, 0);
+  assert.equal(fs.existsSync(configPath), false);
+  assert.equal(fs.existsSync(path.join(cwd, 'n.codes.capabilities.yaml')), false);
+  assert.equal(fs.existsSync(path.join(cwd, '.n.codes.cache.json')), false);
 });
 
 test('main shows version', async () => {
@@ -82,7 +96,7 @@ test('main reports unknown options', async () => {
 test('main runs sync in dry-run mode', async () => {
   const cwd = createTempDir();
   writeFile(cwd, 'src/components/Widget.tsx', 'export const Widget = () => null;');
-  const io = createMemoryIO({ responses: ['openai', 'gpt-4o', 'Demo', 'test-key'] });
+  const io = createMemoryIO({ responses: ['openai', 'gpt-4o', 'n', 'Demo', 'test-key'] });
   const code = await main(['sync', '--dry-run'], { cwd, io });
   assert.equal(code, 0);
   assert.ok(io.getLogs().some((line) => line.includes('dry-run')));

--- a/cli/tests/config.test.js
+++ b/cli/tests/config.test.js
@@ -19,6 +19,7 @@ test('defaultConfig provides baseline values', () => {
   assert.equal(config.provider, 'openai');
   assert.equal(config.model, 'default');
   assert.equal(config.capabilityMapPath, 'n.codes.capabilities.yaml');
+  assert.equal(config.allowHeuristicFallback, false);
 });
 
 test('provider validation normalizes and checks supported list', () => {

--- a/cli/tests/dev.test.js
+++ b/cli/tests/dev.test.js
@@ -7,9 +7,10 @@ const { buildIncrementalMap, runDev } = require('../lib/dev');
 const { createTempDir, writeFile } = require('./helpers');
 const { createMemoryIO } = require('../lib/io');
 const { saveCache } = require('../lib/cache');
+const { parseCapabilityMapYaml } = require('../lib/capability-map');
 
 test('buildIncrementalMap records changed files', () => {
-  const map = buildIncrementalMap({
+  const { map } = buildIncrementalMap({
     fileIndex: { 'src/components/Card.tsx': { size: 1, mtimeMs: 1 } },
     changedFiles: ['src/components/Card.tsx'],
     config: {},
@@ -18,7 +19,7 @@ test('buildIncrementalMap records changed files', () => {
 });
 
 test('buildIncrementalMap applies project name', () => {
-  const map = buildIncrementalMap({
+  const { map } = buildIncrementalMap({
     fileIndex: { 'src/components/Card.tsx': { size: 1, mtimeMs: 1 } },
     changedFiles: [],
     config: { projectName: 'Demo' },
@@ -26,7 +27,7 @@ test('buildIncrementalMap applies project name', () => {
   assert.equal(map.projectName, 'Demo');
 });
 
-test('runDev updates map and cache', () => {
+test('runDev updates map and cache', async () => {
   const cwd = createTempDir();
   writeFile(cwd, 'src/components/Card.tsx', 'export const Card = () => null;');
 
@@ -38,7 +39,27 @@ test('runDev updates map and cache', () => {
   });
 
   const io = createMemoryIO();
-  const result = runDev({ cwd, fs, path, io });
+  const result = await runDev({ cwd, fs, path, io });
   assert.ok(fs.existsSync(result.mapPath));
   assert.ok(result.changedFiles.length >= 0);
+});
+
+test('runDev enriches routes with analysis metadata', async () => {
+  const cwd = createTempDir();
+  writeFile(cwd, 'pages/api/bookings/index.ts', 'export async function POST() { return {}; }');
+  fs.writeFileSync(
+    path.join(cwd, 'n.codes.config.json'),
+    JSON.stringify({ provider: 'openai', model: 'gpt-5-mini', allowHeuristicFallback: true }, null, 2),
+    'utf8'
+  );
+  const originalKey = process.env.OPENAI_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  const io = createMemoryIO();
+  const result = await runDev({ cwd, fs, path, io });
+  process.env.OPENAI_API_KEY = originalKey;
+  const content = fs.readFileSync(result.mapPath, 'utf8');
+  const map = parseCapabilityMapYaml(content);
+  assert.ok(map.actions.postBookings);
+  assert.equal(map.actions.postBookings.analysisSource, 'heuristic');
+  assert.deepEqual(map.actions.postBookings.entities, []);
 });

--- a/cli/tests/init.test.js
+++ b/cli/tests/init.test.js
@@ -9,6 +9,7 @@ const {
   formatModelChoices,
   parseModelChoice,
   normalizeAnswer,
+  parseYesNo,
   runInit,
 } = require('../lib/init');
 const { createMemoryIO } = require('../lib/io');
@@ -55,16 +56,23 @@ test('normalizeAnswer falls back when empty', () => {
   assert.equal(normalizeAnswer('  value ', 'fallback'), 'value');
 });
 
+test('parseYesNo handles inputs', () => {
+  assert.equal(parseYesNo('y', false), true);
+  assert.equal(parseYesNo('no', true), false);
+  assert.equal(parseYesNo('', false), false);
+});
+
 test('runInit writes config file with provider and model', async () => {
   const cwd = createTempDir();
-  // Order: provider, model choice (number), project name, api key
-  const io = createMemoryIO({ responses: ['openai', '1', 'Demo', 'test-key'] });
+  // Order: provider, model choice (number), fallback, project name, api key
+  const io = createMemoryIO({ responses: ['openai', '1', 'n', 'Demo', 'test-key'] });
   const result = await runInit({ cwd, fs, path, io });
   assert.ok(fs.existsSync(result.path));
   const config = JSON.parse(fs.readFileSync(result.path, 'utf8'));
   assert.equal(config.provider, 'openai');
   assert.equal(config.model, 'gpt-5-mini');
   assert.equal(config.projectName, 'Demo');
+  assert.equal(config.allowHeuristicFallback, false);
   const envPath = path.join(cwd, '.env.local');
   const envContent = fs.readFileSync(envPath, 'utf8');
   assert.ok(envContent.includes('OPENAI_API_KEY=test-key'));
@@ -72,10 +80,11 @@ test('runInit writes config file with provider and model', async () => {
 
 test('runInit stores null project name when empty', async () => {
   const cwd = createTempDir();
-  const io = createMemoryIO({ responses: ['claude', '2', '', 'test-key'] });
+  const io = createMemoryIO({ responses: ['claude', '2', '', '', 'test-key'] });
   const result = await runInit({ cwd, fs, path, io });
   const config = JSON.parse(fs.readFileSync(result.path, 'utf8'));
   assert.equal(config.provider, 'claude');
   assert.equal(config.model, 'claude-opus-4-5');
   assert.equal(config.projectName, null);
+  assert.equal(config.allowHeuristicFallback, false);
 });

--- a/cli/tests/reset.test.js
+++ b/cli/tests/reset.test.js
@@ -1,0 +1,49 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { runReset } = require('../lib/reset');
+const { defaultConfig } = require('../lib/config');
+const { createMemoryIO } = require('../lib/io');
+const { createTempDir } = require('./helpers');
+
+test('runReset deletes config, map, and cache files', () => {
+  const cwd = createTempDir();
+  const configPath = path.join(cwd, 'n.codes.config.json');
+  const mapPath = path.join(cwd, 'custom.cap.yaml');
+  const cachePath = path.join(cwd, '.n.codes.cache.json');
+  const envPath = path.join(cwd, '.env.local');
+
+  const config = { ...defaultConfig(), capabilityMapPath: 'custom.cap.yaml' };
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8');
+  fs.writeFileSync(mapPath, 'version: 1', 'utf8');
+  fs.writeFileSync(cachePath, JSON.stringify({}), 'utf8');
+  fs.writeFileSync(envPath, 'OPENAI_API_KEY=test-key\n', 'utf8');
+
+  const io = createMemoryIO();
+  const result = runReset({ cwd, fs, path, io, configPath: null });
+
+  assert.equal(result.config, true);
+  assert.equal(result.map, true);
+  assert.equal(result.cache, true);
+  assert.equal(fs.existsSync(configPath), false);
+  assert.equal(fs.existsSync(mapPath), false);
+  assert.equal(fs.existsSync(cachePath), false);
+  assert.equal(fs.existsSync(envPath), true);
+});
+
+test('runReset --all removes additional n.codes files', () => {
+  const cwd = createTempDir();
+  const extra = path.join(cwd, 'n.codes.extra.json');
+  const hidden = path.join(cwd, '.n.codes.extra.txt');
+  fs.writeFileSync(extra, '{}', 'utf8');
+  fs.writeFileSync(hidden, 'hello', 'utf8');
+
+  const io = createMemoryIO();
+  const result = runReset({ cwd, fs, path, io, configPath: null, all: true });
+
+  assert.ok(typeof result.additional === 'number');
+  assert.equal(fs.existsSync(extra), false);
+  assert.equal(fs.existsSync(hidden), false);
+});


### PR DESCRIPTION
## Summary
- integrate LLM-based analysis into sync/dev with caching and entity merge
- add reset command (with --all) and sync sampling for quick tests
- tighten LLM prompt and request options for provider compatibility
- document capability map example and update CLI options/tests

## Testing
- npm run coverage